### PR TITLE
MIT license as default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
   "github_user": "DonalChilde",
   "version": "0.0.0",
   "copyright_year": "{% now 'utc', '%Y' %}",
-  "license": ["MIT", "Apache-2.0", "GPL-3.0"],
+  "license": "MIT",
   "keywords": "python",
   "development_status": [
     "Development Status :: 1 - Planning",

--- a/{{ cookiecutter.project_name}}/LICENSE
+++ b/{{ cookiecutter.project_name}}/LICENSE
@@ -1,5 +1,6 @@
 # License
 <!-- license-begin -->
+{% if cookiecutter.license == 'MIT' %}
 MIT License
 
 Copyright (c) {{ cookiecutter.copyright_year }}, {{ cookiecutter.author }}
@@ -21,4 +22,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+{% else %}
+    License not defined.
+{% endif %}
 <!-- license-end -->

--- a/{{ cookiecutter.project_name}}/pyproject.toml
+++ b/{{ cookiecutter.project_name}}/pyproject.toml
@@ -4,14 +4,6 @@ build-backend = "flit_core.buildapi"
 
 [project]
 keywords = {{ cookiecutter.keywords.split() }}
-name = "{{ cookiecutter.project_name }}"
-readme = "README.md"
-requires-python = ">=3.10"
-license = { file = "LICENSE" }
-authors = [
-    { name = "{{ cookiecutter.author }}" },
-    { email = "{{ cookiecutter.email }}" },
-]
 classifiers = [
     "{{ cookiecutter.development_status }}",
     "Programming Language :: Python",
@@ -22,6 +14,17 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+{% if cookiecutter.license == 'MIT' %}
+    "License :: OSI Approved :: MIT License",
+{% endif %}
+]
+name = "{{ cookiecutter.project_name }}"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+    { name = "{{ cookiecutter.author }}" },
+    { email = "{{ cookiecutter.email }}" },
 ]
 dynamic = ["version", "description"]
 dependencies = ["click"]


### PR DESCRIPTION
Make the MIT license the default for new projects. If a different license is desired, the LICENSE file and pyproject.toml classifier will need to be updated.